### PR TITLE
set pod_name as env value for leader election

### DIFF
--- a/charts/node-wizard/templates/deployment.yaml
+++ b/charts/node-wizard/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
           value: "{{ .Values.env.forceDeletePods | default "true" }}"
         - name: METRIC_PORT
           value: "{{ .Values.service.targetPort | default "8989" }}"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports:
           - containerPort: {{ .Values.service.targetPort | default "8989" }}
             name: metrics


### PR DESCRIPTION
currently leader election is broken because of the this missing env value. Lets fix it!